### PR TITLE
Source retention enhancement to windows patch script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 RunMe+.cmd
 PutApkHere/orig.apk
-tools/apktool.jar
+tools/
 __MODDED_APK_OUT__/
 patches_out/
 decompile_out/
+source/

--- a/RunMe.bat
+++ b/RunMe.bat
@@ -125,13 +125,16 @@ move %a_out%\mod.apk %a_out%\mod-%ver%.apk >nul
 echo.-: Cleaning up...
 if !keepSource!==keep (
    if not exist %s_out% (mkdir %s_out%)
-   set tstamp=%date:~4,2%%date:~7,2%%date:~10,2%.%time:~0,2%%time:~3,2%
-   move %d_out% %s_out%\%goVers%-%tstamp%
-   echo.-:    Patched source saved in %s_out%\%goVers%-%tstamp%
+   for /f "usebackq tokens=2,3,4,5,6,7 delims=/:. " %%g in (`echo %DATE% %TIME%`) do (
+   	   set y=%%i
+   	   set stamp=%%g%%h%y:~2,2%%%j%%k%%l
+   )
+   move %d_out% %s_out%\%goVers%-%stamp%
+   echo.-:    Patched source saved in %s_out%\%goVers%-%stamp%
 ) else (
    echo.-:    Deleting decompiled source...
    rd /S /Q %d_out%)
-echo.-:    Deleting seleceted patches cache... & rd /S /Q %p_out%
+echo.-:    Deleting selected patches cache... & rd /S /Q %p_out%
 echo.-: Have fun and stay safe
 pause
 exit

--- a/download_tools.bat
+++ b/download_tools.bat
@@ -1,8 +1,8 @@
-mkdir tools
+@echo off
+if not exist tools mkdir tools
 java -jar download.jar https://bitbucket.org/iBotPeaches/apktool/downloads/apktool_2.2.4.jar apktool.jar
 java -jar download.jar https://github.com/jingle1267/BSPatch/raw/master/test/bsdiff4.3-win32/bspatch.exe bspatch.exe
 java -jar download.jar https://sourceforge.mirrorservice.org/g/gn/gnuwin32/patch/2.5.9-7/patch-2.5.9-7-bin.zip patch.zip
 move tools\unzip\bin\patch.exe tools\patch.exe
 del /q tools\patch.zip
 rmdir /s /q tools\unzip
-


### PR DESCRIPTION
Very simple implementation that adds switch to keep source. Source tree is moved to source/ directory, named with GO4 version name and timestamp. Each run is saved separately so different configurations are preserved.

Intended for developers patching GO3/4.

Also cleaned up feedback in download_tools.bat to be simpler to understand for non-techies. Updated .gitignore to ignore source/