### PR TITLE
remove colons in logfile name for WSL compatibility

### DIFF
--- a/RunMeNg.sh
+++ b/RunMeNg.sh
@@ -215,7 +215,7 @@ outdir="__MODDED_APK_OUT__"
 
 timestamp=$(date -u +"%Y-%M-%dT%R:%S")
 
-log_file="$outdir/log-cfg-$timestamp.txt"
+log_file="$outdir/log-cfg-${timestamp//:/_}.txt"
 
 touch $log_file
 

--- a/decompile_apk.sh
+++ b/decompile_apk.sh
@@ -34,7 +34,7 @@ else
 	timestamp=$3
 fi
 
-log_file="$outdir/log-cfg-$timestamp.txt"
+log_file="$outdir/log-cfg-${timestamp//:/_}.txt"
 
 while true; do
 if [ -e PutApkHere/$1 ]

--- a/patch_apk.sh
+++ b/patch_apk.sh
@@ -32,7 +32,7 @@ else
 	timestamp=$2
 fi
 
-log_file="$outdir/log-cfg-$timestamp.txt"
+log_file="$outdir/log-cfg-${timestamp//:/_}.txt"
 
 cd $1
 apkver=`cat apktool.yml | grep versionName: | awk '{print $2}'`


### PR DESCRIPTION
Windows subsystem for Linux (WSL) doesn't support colons in filenames, this should fix it