### PR TITLE
Patch to remove Motor Current Error on Mavic Pro Platinium

### DIFF
--- a/Patch-Descriptions.txt
+++ b/Patch-Descriptions.txt
@@ -60,3 +60,6 @@ activates point of interest for inspire 2. this has not been fully tested, be ca
 MakeDBPublic:
 will move the app private database dji.db wich is normally located at /data/data/dji.go.v4/databases/dji.db to /mnt/sdcard/DJI/dji_mod_{version_string}.db
 This database hold the recorded missions and moving it in user public area allow to do offline flight planning on non rooted devices ( https://www.dropbox.com/s/ne4rk6l7dr3qphj/Tutorial%20DJI%20Waypoints%20with%20Spark.pdf?dl=0 )
+
+RemovePlatiniumMotorPropError(FW<1.03.1000):
+Removes the "Motor current error. Check your propellers and fly with caution." pop-up on Mavic Pro Platinium when using flight controler modules (305 & 306) which come from Firmware < 1.03.1000

--- a/patches/4.1.14-1027326/RemovePlatiniumMotorPropError(FW<1.03.1000).patch
+++ b/patches/4.1.14-1027326/RemovePlatiniumMotorPropError(FW<1.03.1000).patch
@@ -1,0 +1,12 @@
+diff -Naur orig/smali_classes5/dji/pilot/publics/c/h.smali mod/smali_classes5/dji/pilot/publics/c/h.smali
+--- orig/smali_classes5/dji/pilot/publics/c/h.smali	2017-11-17 17:31:17.000000000 +0100
++++ mod/smali_classes5/dji/pilot/publics/c/h.smali	2017-11-23 15:21:26.000000000 +0100
+@@ -5176,6 +5178,8 @@
+     invoke-virtual {p1}, Ldji/midware/data/model/P3/DataOsdGetPushHome;->isFanCurrentInAbnormalState()Z
+ 
+     move-result v1
++	
++     const v1, 0x0
+ 
+     .line 814
+     iget-boolean v0, p0, Ldji/pilot/publics/c/h;->E:Z

--- a/patches/4.1.15-3027412/RemovePlatiniumMotorPropError(FW<1.03.1000).patch
+++ b/patches/4.1.15-3027412/RemovePlatiniumMotorPropError(FW<1.03.1000).patch
@@ -1,0 +1,12 @@
+diff -Naur orig/smali_classes5/dji/pilot/publics/c/h.smali mod/smali_classes5/dji/pilot/publics/c/h.smali
+--- orig/smali_classes5/dji/pilot/publics/c/h.smali	2017-11-17 17:31:17.000000000 +0100
++++ mod/smali_classes5/dji/pilot/publics/c/h.smali	2017-11-23 15:21:26.000000000 +0100
+@@ -5176,6 +5178,8 @@
+     invoke-virtual {p1}, Ldji/midware/data/model/P3/DataOsdGetPushHome;->isFanCurrentInAbnormalState()Z
+ 
+     move-result v1
++	
++     const v1, 0x0
+ 
+     .line 814
+     iget-boolean v0, p0, Ldji/pilot/publics/c/h;->E:Z


### PR DESCRIPTION
Remove the "Motor current error. Check your propellers and fly with caution." pop-up when flying with modules 305 & 306 which come from FW < 1.03.1000