### PR TITLE
restore PlatinumMotorCurrentError for 4.1.22

### DIFF
--- a/patches/4.1.22-3028592/removePlatinumMotorPropError(FW1.03.1000-).patch
+++ b/patches/4.1.22-3028592/removePlatinumMotorPropError(FW1.03.1000-).patch
@@ -1,0 +1,12 @@
+diff -Naur orig/smali_classes6/dji/pilot/publics/d/h.smali mod/smali_classes6/dji/pilot/publics/d/h.smali  
+--- orig/smali_classes6/dji/pilot/publics/d/h.smali  2018-02-18 14:15:17.209975227 +0100  
++++ mod/smali_classes6/dji/pilot/publics/d/h.smali  2018-02-18 14:15:08.813860255 +0100  
+@@ -5196,6 +5196,8 @@  
+   
+     move-result v1  
+   
++    const v1, 0x0  
++  
+     .line 812  
+     iget-boolean v0, p0, Ldji/pilot/publics/d/h;->E:Z
+


### PR DESCRIPTION
Remove the Current motor error pop-up on Platinum when running  modules 305&306 which come from FW01.03.700 or lower