### PR TITLE
Fix logfile dir creation

### DIFF
--- a/RunMe.sh
+++ b/RunMe.sh
@@ -238,6 +238,9 @@ add_timestamp=$(echo $add_timestamp | tr '[:upper:]' '[:lower:]')
 iconrep_step=$(echo $iconrep_step | tr '[:upper:]' '[:lower:]')
 iconmod_step=$(echo $iconmod_step | tr '[:upper:]' '[:lower:]')
 
+# Create outdir
+mkdir $outdir 2>&1 >/dev/null
+
 # Create the log file
 touch $log_file
 


### PR DESCRIPTION
Fixes `RunMe.sh`
```
...
========================================
   Running script on an Linux system
========================================
touch: cannot touch '__MODDED_APK_OUT__/log-cfg-2018-03-25T22_03_21.txt': No such file or directory

========================================
         Configuration Summary
========================================
...
```
