### PR TITLE
gitignore changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 RunMe+.cmd
-PutApkHere/orig.apk
+PutApkHere/*.apk
 tools/
 __MODDED_APK_OUT__/
 patches_out/
-decompile_out/
+decompile_out*/
 source/
+mod/
+orig/


### PR DESCRIPTION
changes to `.gitignore`

- all apk's inside `PutApkHere` are ignored
- all dirs starting with name `decompile_out` are ignored
- ignore `mod/` and `orig/` dirs in main repository